### PR TITLE
Fix json parse for >=1.20.3

### DIFF
--- a/database/server.go
+++ b/database/server.go
@@ -30,10 +30,10 @@ type Lockdown struct {
 
 type PingResponse struct {
 	Online      bool
-	Version     VersionData       `json:"version"`
-	Players     PlayersData       `json:"players"`
-	Description map[string]string `json:"description"`
-	Favicon     string            `json:"favicon"`
+	Version     VersionData `json:"version"`
+	Players     PlayersData `json:"players"`
+	Description interface{} `json:"description"`
+	Favicon     string      `json:"favicon"`
 }
 
 type VersionData struct {

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -220,6 +220,13 @@ func (s *grpcServer) Lockdown_PBtoDB(pbEntry *pb.Lockdown) *database.Lockdown {
 }
 
 func (s *grpcServer) Status_DBtoPB(dbEntry database.PingResponse) *pb.ServerStatus {
+	var description string
+	if str, ok := dbEntry.Description.(string); ok {
+		description = str
+	} else if m, ok := dbEntry.Description.(map[string]string); ok {
+		description = m["text"]
+	}
+
 	return &pb.ServerStatus{
 		Online: dbEntry.Online,
 		Version: &pb.ServerStatus_Version{
@@ -230,7 +237,7 @@ func (s *grpcServer) Status_DBtoPB(dbEntry database.PingResponse) *pb.ServerStat
 			Max:    int32(dbEntry.Players.Max),
 			Online: int32(dbEntry.Players.Online),
 		},
-		Description: dbEntry.Description["text"],
+		Description: description,
 		Favicon:     dbEntry.Favicon,
 	}
 }


### PR DESCRIPTION
> Plain-text chat components (text, no sibilings, no stylings) are now always serialized as string instead of {"text": "your text"}.

https://minecraft.wiki/w/Java_Edition_1.20.3